### PR TITLE
Port Temporal 101 exercise 1 to Haskell

### DIFF
--- a/temporal101/Exercise1.hs
+++ b/temporal101/Exercise1.hs
@@ -68,8 +68,7 @@ main = bracket setup teardown $ \_worker -> do
   -- the worker's running in its own thread, we just have to keep this
   -- one alive (one one-second threadDelay at a time) for as long as we
   -- want to execute workflows on it
-  forever $ threadDelay 1_000_000
-  pure ()
+  forever $ threadDelay maxBound
   where
     setup = do
       runtime <- initializeRuntime NoTelemetry

--- a/temporal101/Exercise1.hs
+++ b/temporal101/Exercise1.hs
@@ -2,7 +2,7 @@ module Main where
 
 import Control.Monad (forever)
 import Control.Monad.IO.Class (liftIO)
-import Control.Monad.Logger (defaultOutput)
+import Control.Monad.Logger (defaultOutput, runStdoutLoggingT)
 import Control.Monad.Trans.Reader (runReaderT)
 import Data.Aeson (FromJSON, ToJSON)
 import Data.Text (Text)

--- a/temporal101/Exercise1.hs
+++ b/temporal101/Exercise1.hs
@@ -75,7 +75,7 @@ main = bracket setup teardown $ \_worker -> do
       runtime <- initializeRuntime NoTelemetry
       -- coreClient is needed to construct a worker, even though we're
       -- not constructing a client
-      coreClient <- connectClient runtime defaultClientConfig
+      coreClient <- runStdoutLoggingT $ connectClient runtime defaultClientConfig
 
       -- startWorker starts a Temporal worker and returns a handle to
       -- it. the Temporal control plane can dispatch to the worker, or

--- a/temporal101/Exercise1.hs
+++ b/temporal101/Exercise1.hs
@@ -1,0 +1,98 @@
+module Main where
+
+import Control.Monad (forever)
+import Control.Monad.IO.Class (liftIO)
+import Control.Monad.Logger (defaultOutput)
+import Control.Monad.Trans.Reader (runReaderT)
+import Data.Aeson (FromJSON, ToJSON)
+import Data.Text (Text)
+import Data.UUID qualified as UUID
+import Data.UUID.V4 qualified as UUID.V4
+import DiscoverInstances (discoverInstances)
+import GHC.Generics (Generic)
+import RequireCallStack (RequireCallStack, provideCallStack)
+import System.IO (stdout)
+import Temporal.Activity (Activity)
+import Temporal.Client (mkWorkflowClientConfig, workflowClient)
+import Temporal.Client qualified as Client
+import Temporal.Core.Client (connectClient, defaultClientConfig)
+import Temporal.Duration (seconds)
+import Temporal.Payload (JSON (JSON))
+import Temporal.Runtime (TelemetryOptions (..), initializeRuntime)
+import Temporal.TH (WorkflowFn, ActivityFn)
+import Temporal.TH qualified
+import Temporal.Worker (Worker, WorkerConfig, startWorker)
+import Temporal.Worker qualified as Worker
+import Temporal.Workflow (Workflow, WorkflowId (..))
+import Temporal.Workflow qualified as Workflow
+import UnliftIO.Concurrent (threadDelay)
+import UnliftIO.Exception (bracket)
+
+-- | The official "Hello, Workflow" example takes a bare string as input.
+-- Here we reinforce the pattern of creating a record type for inputs so
+-- that it can evolve freely.
+data SayHelloInput = SayHelloInput
+  { name :: Text
+  }
+  deriving stock (Generic, Show)
+  deriving anyclass (FromJSON, ToJSON)
+
+-- sayHelloActivity :: SayHelloInput -> Activity () Text
+-- sayHelloActivity input = do
+--   pure $ "Hello, " <> input.name
+
+-- Temporal.TH.registerActivity 'sayHelloActivity
+-- Temporal.TH.bringRegisteredTemporalFunctionsIntoScope
+
+-- activityOptions :: Workflow.StartActivityOptions
+-- activityOptions = Workflow.defaultStartActivityOptions (Workflow.StartToClose $ seconds 1)
+
+-- | We don't execute an activity in this workflow, we execute code
+-- directly (why?).
+sayHelloWorkflow :: SayHelloInput -> Workflow Text
+sayHelloWorkflow input = provideCallStack do
+  pure $ "Hello, " <> input.name
+  -- Workflow.executeActivity SayHelloActivity activityOptions input
+
+Temporal.TH.registerWorkflow 'sayHelloWorkflow
+Temporal.TH.bringRegisteredTemporalFunctionsIntoScope
+
+taskQueue :: Workflow.TaskQueue
+taskQueue = "hello-world"
+
+namespace :: Workflow.Namespace
+namespace = "default"
+
+workerConfig :: WorkerConfig ()
+workerConfig = provideCallStack $ Worker.configure environment definitions settings
+  where
+    environment = ()
+    definitions :: RequireCallStack => Worker.Definitions ()
+    definitions = Temporal.TH.discoverDefinitions @() $$(discoverInstances) $$(discoverInstances)
+    settings = do
+      Worker.setNamespace namespace
+      Worker.setTaskQueue taskQueue
+      Worker.setLogger (defaultOutput stdout)
+
+main :: IO ()
+main = bracket setup teardown $ \_worker -> do
+  -- the worker's running in its own thread, we just have to keep this
+  -- one alive (one one-second threadDelay at a time) for as long as we
+  -- want to execute workflows on it
+  forever $ threadDelay 1_000_000
+  pure ()
+  where
+    setup = do
+      runtime <- initializeRuntime NoTelemetry
+      -- coreClient is needed to construct a worker, even though we're
+      -- not constructing a client
+      coreClient <- connectClient runtime defaultClientConfig
+
+      -- startWorker starts a Temporal worker and returns a handle to
+      -- it. the Temporal control plane can dispatch to the worker, or
+      -- you can run workflows on it directly
+      worker <- startWorker coreClient workerConfig
+
+      pure worker
+
+    teardown worker = Worker.shutdown worker

--- a/temporal101/Exercise1.hs
+++ b/temporal101/Exercise1.hs
@@ -37,22 +37,11 @@ data SayHelloInput = SayHelloInput
   deriving stock (Generic, Show)
   deriving anyclass (FromJSON, ToJSON)
 
--- sayHelloActivity :: SayHelloInput -> Activity () Text
--- sayHelloActivity input = do
---   pure $ "Hello, " <> input.name
-
--- Temporal.TH.registerActivity 'sayHelloActivity
--- Temporal.TH.bringRegisteredTemporalFunctionsIntoScope
-
--- activityOptions :: Workflow.StartActivityOptions
--- activityOptions = Workflow.defaultStartActivityOptions (Workflow.StartToClose $ seconds 1)
-
 -- | We don't execute an activity in this workflow, we execute code
 -- directly (why?).
 sayHelloWorkflow :: SayHelloInput -> Workflow Text
 sayHelloWorkflow input = provideCallStack do
   pure $ "Hello, " <> input.name
-  -- Workflow.executeActivity SayHelloActivity activityOptions input
 
 Temporal.TH.registerWorkflow 'sayHelloWorkflow
 Temporal.TH.bringRegisteredTemporalFunctionsIntoScope

--- a/temporal101/README.md
+++ b/temporal101/README.md
@@ -1,0 +1,78 @@
+# Temporal 101 exercises, in Haskell
+
+This directory contains several exercises that will help you learn the
+basics of writing applications with Temporal, based on the [Temporal
+101: Introducing the Temporal
+Platform](https://learn.temporal.io/courses/temporal_101/) courses.
+
+## Running the exercises
+
+As with other Temporal cookbook environments, you'll start a nix shell
+with `nix develop --accept-flake-config` in two terminals, one where you
+plan to run code and one where you'll run the Temporal server. In the
+latter, run:
+
+```bash
+$ temporal server start-dev
+```
+
+This will start a long-running control plane server that will execute
+workflows against workers you write.
+
+### A note on exercise format
+
+These exercises are structured slightly differently from the exercises
+in the official courses. They're meant to mirror the
+one-file-per-example structure of the examples in `hello/`, and they
+follow the pattern of structuring input with a type (rather than, say, a
+string) which Mercury uses as a best practice.
+
+## Exercise 1: Build a simple worker and workflow
+
+### Part A: Review the workflow and worker logic
+
+Inspect `Exercise1.hs` and find the definition of `sayHelloWorkflow`.
+Review its type signature. Next, review the `main` function and its
+pattern for creating and tearing down a worker.
+
+### Part B: Change the task queue name for the worker
+
+Change the name of the task queue to `greeting-tasks`.
+
+### Part C: Start the worker
+
+Build and run the worker with:
+
+```bash
+$ cabal run temporal101:exercise1
+```
+
+### Part D: Start the workflow from the command line
+
+Open another nix shell in the `temporal101` directory. Run the following
+command to instruct the Temporal server to run your workflow:
+
+```bash
+$ temporal workflow start \
+    --type Main.sayHelloWorkflow \
+    --task-queue greeting-tasks \
+    --workflow-id my-first-workflow \
+    --input '{"name": "<your name here>"}'
+```
+
+Note that the Haskell module (`Main`) is part of the workflow type name.
+
+### Part E: View the workflow's status and output
+
+From the command line, run:
+
+```bash
+$ temporal workflow show --workflow-id "my-first-workflow"
+```
+
+Is the output what you expect?
+
+You can examine the workflow's execution in a web interface, too. In a
+browser, open `localhost:8233` and click into the workflow you just ran.
+If you made a mistake in the inputs, this will make it easier to
+diagnose than reading the log output of the worker in the terminal.

--- a/temporal101/temporal101.cabal
+++ b/temporal101/temporal101.cabal
@@ -1,0 +1,40 @@
+cabal-version: 3.0
+
+name:       temporal101
+version:    0.0.0
+license:    MPL-2.0
+build-type: Simple
+author:     Mercury Technologies Inc.
+maintainer: temporal@mercury.com
+copyright:  2025 Mercury Technologies Inc.
+
+common all
+  default-language: GHC2021
+  default-extensions:
+    BlockArguments,
+    DeriveAnyClass,
+    DerivingVia,
+    OverloadedRecordDot,
+    OverloadedStrings,
+    TemplateHaskell,
+    TypeFamilies,
+    UndecidableInstances,
+  ghc-options: -threaded -rtsopts -with-rtsopts=-N
+  build-depends:
+    base,
+    aeson,
+    discover-instances,
+    monad-logger,
+    require-callstack,
+    text,
+    temporal-sdk-core,
+    temporal-sdk,
+    transformers,
+    unliftio,
+    uuid,
+
+common executables
+
+executable exercise1
+  import: all
+  main-is: Exercise1.hs


### PR DESCRIPTION
[Typescript original](https://github.com/temporalio/edu-101-typescript-code/tree/main/exercises/hello-workflow)

I'm taking a few liberties with this one:
- The typescript version includes a client that invokes a workflow, but doesn't actually _do anything_ with it in the readme's instructions. I'm moving "client invokes a workflow on a running worker" into exercise 2.
- Our Temporal artifacts are encrypted or something, so `tomporal workflow show --workflow-id "foo"` doesn't produce readable output. Instead, I'm moving the "look at the web ui" element from exercise 2 into exercise 1. (Looking in the web UI also made it a lot easier to debug things for me.)

```bash
[nix] 15:33:46 $ temporal workflow show --workflow-id "my-sixth-workflow"
Progress:
  ID           Time                     Type           
    1  2025-05-28T22:33:46Z  WorkflowExecutionStarted  
    2  2025-05-28T22:33:46Z  WorkflowTaskScheduled     
    3  2025-05-28T22:33:46Z  WorkflowTaskStarted       
    4  2025-05-28T22:33:46Z  WorkflowTaskCompleted     
    5  2025-05-28T22:33:46Z  WorkflowExecutionCompleted

Results:
  Status          COMPLETED
  Result          {"metadata":{"encoding":"anNvbi9wbGFpbg==","messageType":"VGV4dA=="},"data":"IkhlbGxvLCBNYXR0Ig=="}
  ResultEncoding  json/plain
```