### PR TITLE
Port retry-policy self-study example to Haskell

### DIFF
--- a/temporal101/HelloServer.hs
+++ b/temporal101/HelloServer.hs
@@ -1,10 +1,23 @@
+import Data.IORef
+import Network.HTTP.Types.Status
 import Web.Scotty
 
 main :: IO ()
-main = scotty 9001 $ do
-  get "/hello/:name" $ do
-    name <- pathParam "name"
-    text $ "¡Hola, " <> name <> "!"
-  get "/goodbye/:name" $ do
-    name <- pathParam "name"
-    text $ "¡Adios, " <> name <> "!"
+main = do
+  attempts <- newIORef 0
+  scotty 9001 $ do
+    get "/hello/:name" $ do
+      name <- pathParam "name"
+      text $ "¡Hola, " <> name <> "!"
+    get "/goodbye/:name" $ do
+      name <- pathParam "name"
+      text $ "¡Adios, " <> name <> "!"
+    get "/sometimesBusy" $ do
+      liftIO $ modifyIORef' attempts (+1)
+      attempt <- liftIO $ readIORef attempts
+      if attempt < 3 then failureResponse else successResponse
+      where
+        failureResponse = do
+          status status429
+          text "please call back later"
+        successResponse = text "thank you, drive through"

--- a/temporal101/README.md
+++ b/temporal101/README.md
@@ -225,3 +225,43 @@ workflow you just ran.
 
 In the `temporal101` directory, you should find a PDF. Open that in the
 web browser and enjoy.
+
+## Extra Study: Retry policies
+
+Part of Temporal's value proposition is durable execution in the face of
+temporary failure. Let's look at an example, based around an artificial
+failure on one of `HelloServer`'s endpoints.
+
+### Part A: Inspect the Haskell
+
+Open `RetryPolicy.hs` and note how the activity throws an
+`ApplicationFailure` to signal its failure. Note also the retry policy
+we configure to run the activity.
+
+### Part B: Run the code as-is and examine the failed workflow
+
+In a terminal in the nix shell, run the http service:
+
+```bash
+$ cabal run temporal101:helloserver
+```
+
+In another terminal, run the retry worker:
+
+```bash
+$ cabal run temporal101:retrypolicy
+```
+
+Once the latter has completed, open a web browser to `localhost:8233`
+and examine the failed workflow. Note that it's annotated with the
+number of retries and other metadata about the retry policy in use.
+
+### Part C: Set an improved retry policy
+
+Examine `HelloServer.hs`, then update the `retryPolicy` in
+`RetryPolicy.hs` to something you'd expect to succeed.
+
+### Part D: Rerun the experiment and examine the results
+
+If it's still running, ctrl-C out of `helloserver` and start it again.
+Run the retry worker again, and examine the results in the web UI.

--- a/temporal101/RetryPolicy.hs
+++ b/temporal101/RetryPolicy.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE DuplicateRecordFields #-}
-{-# LANGUAGE DisambiguateRecordFields #-}
 module Main where
 
 import Control.Exception (throw)

--- a/temporal101/RetryPolicy.hs
+++ b/temporal101/RetryPolicy.hs
@@ -44,6 +44,9 @@ trySometimesBusy = do
     -- | Throwing an ApplicationFailure fails the Activity. Temporal
     -- workflows are expected to be robust against activity failures,
     -- though, so by default this won't fail the Workflow's execution.
+    -- If we exceed the retry policy's attempt limit (see below) or flag
+    -- this failure as non-retryable, though, the Workflow will fail
+    -- when the Activity fails.
     errorOut status = throw 
       ApplicationFailure
         { type' = "DidntGet200Error"

--- a/temporal101/RetryPolicy.hs
+++ b/temporal101/RetryPolicy.hs
@@ -1,0 +1,147 @@
+{-# LANGUAGE DuplicateRecordFields #-}
+{-# LANGUAGE DisambiguateRecordFields #-}
+module Main where
+
+import Control.Exception (throw)
+import Control.Monad.IO.Class (liftIO)
+import Control.Monad.Logger (defaultOutput, runStdoutLoggingT)
+import Control.Monad.Trans.Reader (runReaderT)
+import Data.Aeson (FromJSON, ToJSON)
+import Data.Text (Text)
+import Data.Text qualified as Text
+import Data.Text.Encoding (decodeUtf8)
+import Data.UUID qualified as UUID
+import Data.UUID.V4 qualified as UUID.V4
+import DiscoverInstances (discoverInstances)
+import GHC.Generics (Generic)
+import Network.HTTP.Simple (httpBS, getResponseBody, getResponseStatusCode, parseRequest)
+import RequireCallStack (RequireCallStack, provideCallStack)
+import System.IO (stdout)
+import Temporal.Activity (Activity)
+import Temporal.Client (mkWorkflowClientConfig, workflowClient)
+import Temporal.Client qualified as Client
+import Temporal.Core.Client (connectClient, defaultClientConfig)
+import Temporal.Duration (seconds)
+import Temporal.Exception (ApplicationFailure (..))
+import Temporal.Payload (JSON (JSON))
+import Temporal.Runtime (TelemetryOptions (..), initializeRuntime)
+import Temporal.TH (WorkflowFn, ActivityFn)
+import Temporal.TH qualified
+import Temporal.Worker (Worker, WorkerConfig, startWorker)
+import Temporal.Worker qualified as Worker
+import Temporal.Workflow (Workflow, WorkflowId (..))
+import Temporal.Workflow qualified as StartActivityOptions (StartActivityOptions (..))
+import Temporal.Workflow qualified as Workflow
+import UnliftIO.Exception (bracket)
+
+-- | An Activity that calls a local webserver. Activity has a MonadIO
+-- instance so we don't need to provide anything in the environment,
+-- which remains @()@. This time, our Activity adds some error handling
+-- in case the response it gets is not the 200 it expects.
+trySometimesBusy :: Activity () Text
+trySometimesBusy = do
+  resp <- httpBS "http://localhost:9001/sometimesBusy"
+  let status = getResponseStatusCode resp
+  case status of
+    200 -> pure . decodeUtf8 $ getResponseBody resp
+    _ -> errorOut status
+  where
+    -- | Throwing an ApplicationFailure fails the Activity. This can
+    -- happen for many reasons
+    errorOut status = throw 
+      ApplicationFailure
+        { type' = "DidntGet200Error"
+        , message = "Expected a 200 but got a " <> tshow status
+        , nonRetryable = False
+        , details = []
+        , stack = ""
+        , nextRetryDelay = Nothing
+        }
+    tshow = Text.pack . show
+
+Temporal.TH.registerActivity 'trySometimesBusy
+
+retryPolicy :: Workflow.RetryPolicy
+retryPolicy =
+  Workflow.defaultRetryPolicy
+    { -- initialInterval = seconds 1
+      -- backoffCoefficient = 2.0
+      -- maximumInterval = seconds 100
+      Workflow.maximumAttempts = 2
+      -- nonRetryableErrorTypes = []
+    }
+
+activityOptions :: Workflow.StartActivityOptions
+activityOptions =
+  (Workflow.defaultStartActivityOptions (Workflow.StartToClose $ seconds 10))
+    { StartActivityOptions.retryPolicy = Just retryPolicy }
+  
+webRequestWorkflow :: Workflow Text
+webRequestWorkflow = provideCallStack do
+  Workflow.executeActivity TrySometimesBusy activityOptions
+
+Temporal.TH.registerWorkflow 'webRequestWorkflow
+
+taskQueue :: Workflow.TaskQueue
+taskQueue = "activity-task-queue"
+
+namespace :: Workflow.Namespace
+namespace = "default"
+
+-- | A 'WorkerConfig' consists of the following components:
+-- 
+-- * an environment value, which will be passed to any 'Activity' that the
+--   'Worker' picks up
+-- * a set of 'Worker.Definitions', which map 'Workflow' and 'Activity' names
+--   to their implementations
+-- * a stateful configuration record (of type 'Worker.ConfigM'), from which
+--   'WorkerConfig' fields can be set directly
+--
+-- It's important to note that 'Activity' execution environment is available
+-- when constructing 'Worker.ConfigM'; it's empty ('()') in this example, but
+-- in a more involved setting it can be used to share structured logging,
+-- instrumentation, etc. configurations.
+--
+-- Special attention should be paid to 'Temporal.TH.discoverDefinitions': this
+-- macro accepts a type argument for some 'Activity' environment, and two
+-- typeclass dictionaries (a list of 'Temporal.TH.WorkflowFn' and
+-- 'Temporal.TH.ActivityFn') provided by the 'discoverInstances' macro.
+--
+-- Thus, all compatible 'Workflow' and 'Activity' definitions in-scope are
+-- auto-magically gathered; in a much more complex application, activities and
+-- workflows could be defined in their own modules and then brought into scope
+-- in one place for worker & client configuration.
+workerConfig :: WorkerConfig ()
+workerConfig = provideCallStack $ Worker.configure environment definitions settings
+  where
+    environment = ()
+    definitions :: RequireCallStack => Worker.Definitions ()
+    definitions = Temporal.TH.discoverDefinitions $$(discoverInstances) $$(discoverInstances)
+    settings = do
+      Worker.setNamespace namespace
+      Worker.setTaskQueue taskQueue
+      Worker.setLogger (defaultOutput stdout)
+
+main :: IO ()
+main = bracket setup teardown $ \(withClient, worker) -> do
+  workflowId <- WorkflowId . UUID.toText <$> liftIO UUID.V4.nextRandom
+  _result <-
+    withClient $
+      Client.execute
+        WebRequestWorkflow
+        workflowId
+        (Client.startWorkflowOptions taskQueue)
+  pure ()
+  where
+    setup = do
+      runtime <- initializeRuntime NoTelemetry
+      coreClient <- runStdoutLoggingT $ connectClient runtime defaultClientConfig
+
+      worker <- startWorker coreClient workerConfig
+
+      client <- workflowClient coreClient (mkWorkflowClientConfig namespace)
+      let withClient action = runReaderT action client
+
+      pure (withClient, worker)
+
+    teardown (_withClient, worker) = Worker.shutdown worker

--- a/temporal101/temporal101.cabal
+++ b/temporal101/temporal101.cabal
@@ -61,3 +61,7 @@ executable helloserver
 executable exercise4
   import: all
   main-is: Exercise4.hs
+
+executable retrypolicy
+  import: all
+  main-is: RetryPolicy.hs

--- a/temporal101/temporal101.cabal
+++ b/temporal101/temporal101.cabal
@@ -26,6 +26,7 @@ common all
     aeson,
     discover-instances,
     http-conduit,
+    http-types,
     monad-logger,
     require-callstack,
     scotty,


### PR DESCRIPTION
The [retry-policy self-study Typescript example](https://github.com/temporalio/edu-101-typescript-code/tree/main/samples/retry-policy) doesn't have any associated instructions, so I whipped up a contrived example in the `HelloServer` Scotty service and wired in a retry policy that won't succeed without modification. This is a bit more prescriptive than the Typescript course, I think, but it serves as an introduction to how Temporal activities fail and what workflows can do about it.