### PR TITLE
use the time-skipping sdk branch

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -27,16 +27,16 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1750278136,
-        "narHash": "sha256-FW59KHXOXVskcEOEzhAogCOFhrl7+SmW9bDrWBGaU0A=",
+        "lastModified": 1750462458,
+        "narHash": "sha256-PQKc17F5c+RRl3UAPlG2zI1R/BaqcqZsJ3cl/ACJcCQ=",
         "owner": "MercuryTechnologies",
         "repo": "hs-temporal-sdk",
-        "rev": "b1f7ebf77db72b3f982dd112a159554ae4da4a33",
+        "rev": "e768d0a1cf9f2d81c90490aad051bed61cdca6b4",
         "type": "github"
       },
       "original": {
         "owner": "MercuryTechnologies",
-        "ref": "jkachmar/mock-activity-environment",
+        "ref": "time-skipping",
         "repo": "hs-temporal-sdk",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -24,6 +24,7 @@
             inherit system;
             overlays = [
               inputs.hs-temporal-sdk.overlays.temporal-bridge
+              inputs.hs-temporal-sdk.overlays.temporal-test-server
               inputs.hs-temporal-sdk.overlays.haskell-development
             ];
           };
@@ -68,7 +69,7 @@
     };
 
     hs-temporal-sdk = {
-      url = "github:MercuryTechnologies/hs-temporal-sdk/jkachmar/mock-activity-environment";
+      url = "github:MercuryTechnologies/hs-temporal-sdk/time-skipping";
       inputs = {
         # stubbed out to avoid bloating `flake.lock`
         devenv.follows = "";


### PR DESCRIPTION
we want the time-skipping features for temporal102, but we're not quite ready to merge those into the sdk yet, so point at that branch.