### PR TITLE
feat(temporal102): init age-estimation sample

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -1,1 +1,5 @@
-packages: */*.cabal, */*/*.cabal
+packages:
+  hello/,
+  temporal101/,
+  temporal102/*/,
+  temporal102/samples/*/

--- a/temporal102/samples/age-estimation/Client.hs
+++ b/temporal102/samples/age-estimation/Client.hs
@@ -1,0 +1,51 @@
+module Main where
+
+import Shared qualified
+import Workflow (EstimateAgeWorkflow (..))
+
+import Control.Monad.IO.Class (liftIO)
+import Control.Monad.Logger (runStdoutLoggingT)
+import Control.Monad.Trans.Reader (runReaderT)
+import Data.Functor (void)
+import Data.Text qualified as Text
+import Data.UUID qualified as UUID
+import Data.UUID.V4 qualified as UUID.V4
+import System.Environment (getArgs)
+import Temporal.Client (mkWorkflowClientConfig, workflowClient)
+import Temporal.Client qualified as Client
+import Temporal.Core.Client (connectClient, defaultClientConfig)
+import Temporal.Runtime (TelemetryOptions (NoTelemetry), initializeRuntime)
+import Temporal.Workflow (WorkflowHandle (..), WorkflowId (..))
+
+main :: IO ()
+main = do
+  args <- getArgs
+  case args of
+    [name] -> do
+      workflowId <- WorkflowId . UUID.toText <$> liftIO UUID.V4.nextRandom
+      putStrLn $ "Starting workflow with ID: " ++ show workflowId
+
+      client <- mkClient
+      -- Start the workflow without waiting for completion.
+      -- 
+      -- This demonstrates fire-and-forget workflow execution.
+      handle <- flip runReaderT client $ Client.start
+        EstimateAgeWorkflow
+        workflowId
+        (Client.startWorkflowOptions Shared.taskQueue)
+        (Text.pack name)
+
+      let resolvedWorkflowId = rawWorkflowId . Client.workflowHandleWorkflowId $ handle
+      putStrLn $ "Started workflow " <> Text.unpack resolvedWorkflowId
+
+      result <- Client.waitWorkflowResult handle
+      putStrLn $ Text.unpack result
+      
+    _ -> do
+      putStrLn "Must specify a name as the command-line argument"
+  where
+    mkClient = do
+      runtime <- initializeRuntime NoTelemetry
+      coreClient <- runStdoutLoggingT $ connectClient runtime defaultClientConfig
+      workflowClient coreClient (mkWorkflowClientConfig Shared.namespace)
+  

--- a/temporal102/samples/age-estimation/README.md
+++ b/temporal102/samples/age-estimation/README.md
@@ -1,0 +1,46 @@
+# Age Estimation Workflow
+
+This example provides a Workflow that can estimate someone's age, 
+based on their given name. It uses a single Activity implementation, 
+which calls a remote API to retrieve this estimation.
+
+Start the Worker:
+
+```
+cabal run age-estimation:worker
+```
+
+In addition to the Worker, it also includes a file [`Client.hs`](./Client.hs)
+that you can use to run the Workflow (pass a name to use as input 
+on the command line when invoking it). 
+
+```
+cabal run age-estimation:client -- Betty
+```
+
+This will output a message with the name and estimated age:
+
+```
+Betty has an estimated age of 78
+```
+
+## Testing
+
+Additionally, this example provides tests for the Workflow 
+and Activity code.
+
+```
+cabal test age-estimation:spec
+```
+
+This will spawn a temporary development server and a worker configured to
+process the workflow under test.
+
+A successful test run should produce a bunch of interleaved output from
+Temporal along with the following:
+
+```
+Finished in 0.5924 seconds
+3 examples, 0 failures
+Test suite spec: PASS
+```

--- a/temporal102/samples/age-estimation/Shared.hs
+++ b/temporal102/samples/age-estimation/Shared.hs
@@ -1,0 +1,54 @@
+module Shared where
+
+-- NOTE: Required to import workflow instances that this worker will handle.
+import Workflow ()
+
+import Control.Monad.Logger (defaultOutput)
+import Control.Monad.IO.Class (MonadIO)
+import Data.Default (def)
+import DiscoverInstances (discoverInstances)
+import Network.Connection (settingClientSupported)
+import Network.HTTP.Client qualified as HTTP.Client
+import Network.HTTP.Client.TLS (mkManagerSettings, newTlsManagerWith)
+import qualified Network.TLS as TLS
+import RequireCallStack (RequireCallStack, provideCallStack)
+import System.IO (stdout)
+import Temporal.TH (WorkflowFn, ActivityFn)
+import Temporal.TH qualified
+import Temporal.Worker (WorkerConfig)
+import Temporal.Worker qualified as Worker
+import Temporal.Workflow qualified as Workflow
+
+mkWorkerConfig :: HTTP.Client.Manager -> WorkerConfig HTTP.Client.Manager
+mkWorkerConfig manager = provideCallStack $ Worker.configure manager definitions settings
+  where
+    definitions :: RequireCallStack => Worker.Definitions HTTP.Client.Manager
+    definitions = Temporal.TH.discoverDefinitions $$(discoverInstances) $$(discoverInstances)
+    settings = do
+      Worker.setNamespace namespace
+      Worker.setTaskQueue taskQueue
+      Worker.setLogger (defaultOutput stdout)
+
+namespace :: Workflow.Namespace
+namespace = "default"
+
+taskQueue :: Workflow.TaskQueue
+taskQueue = "test"
+
+-- | The third-party service used to implement this example supports TLS, but
+-- does /not/ support TLS1.2+EMS (Extended Main Secret).
+--
+-- The 'http-client-tls' connection manager has 'TLS.RequireEMS' set by
+-- default, which causes requests to fail.
+--
+-- Fortunately this makes for a useful example of how we can use the 'Activity'
+-- environment to as a form of dependency injection.
+newRelaxedEMSManager :: MonadIO m => m HTTP.Client.Manager
+newRelaxedEMSManager = do
+  let tlsSettings = def {
+        settingClientSupported = def {
+          TLS.supportedExtendedMainSecret = TLS.AllowEMS
+        }
+      }
+  newTlsManagerWith $ mkManagerSettings tlsSettings Nothing
+

--- a/temporal102/samples/age-estimation/Worker.hs
+++ b/temporal102/samples/age-estimation/Worker.hs
@@ -1,0 +1,23 @@
+module Main where
+
+import Shared qualified
+
+import Control.Monad (forever)
+import Control.Monad.Logger (runStdoutLoggingT)
+import Temporal.Core.Client (connectClient, defaultClientConfig)
+import Temporal.Runtime (TelemetryOptions (NoTelemetry), initializeRuntime)
+import Temporal.Worker qualified as Worker
+import Temporal.Worker (startWorker)
+import UnliftIO.Concurrent (threadDelay)
+import UnliftIO.Exception (bracket)
+
+main :: IO ()
+main = bracket setup teardown do
+  \_ -> forever $ threadDelay maxBound
+  where
+    setup = do
+      runtime <- initializeRuntime NoTelemetry
+      coreClient <- runStdoutLoggingT $ connectClient runtime defaultClientConfig
+      manager <- Shared.newRelaxedEMSManager
+      startWorker coreClient (Shared.mkWorkerConfig manager)
+    teardown = Worker.shutdown

--- a/temporal102/samples/age-estimation/Workflow.hs
+++ b/temporal102/samples/age-estimation/Workflow.hs
@@ -1,0 +1,62 @@
+module Workflow where
+
+import Control.Exception (throwIO)
+import Control.Monad.IO.Class (liftIO)
+import Control.Monad.Reader (ask)
+import Data.Aeson (FromJSON, ToJSON)
+import Data.Functor ((<&>))
+import Data.Text (Text)
+import Data.Text qualified as Text
+import Data.Text.Encoding (encodeUtf8)
+import GHC.Generics (Generic)
+import Network.HTTP.Client qualified as HTTP.Client
+import Network.HTTP.Simple (
+    getResponseBody,
+    httpJSON,
+    parseRequest,
+    setRequestManager,
+    setRequestQueryString
+  )
+import RequireCallStack (provideCallStack)
+import Temporal.Activity (Activity)
+import Temporal.Duration (seconds)
+import Temporal.Exception (ApplicationFailure (..))
+import Temporal.TH qualified
+import Temporal.Workflow (Workflow)
+import Temporal.Workflow qualified as Workflow
+
+-- | Helper function to render any 'Show'-able type as 'Text'.
+tshow :: Show a => a -> Text
+tshow = Text.pack . show
+
+data EstimatorResponse = EstimatorResponse
+  { age :: Int
+  , count :: Int
+  , name :: Text
+  }
+  deriving stock (Generic, Show)
+  deriving anyclass (ToJSON, FromJSON)
+
+estimateAge :: Text -> Activity HTTP.Client.Manager Int
+estimateAge name = do
+  manager <- ask
+  req <- parseRequest "https://api.agify.io/"
+    <&> setRequestQueryString [("name", Just . encodeUtf8 $ name)]
+    <&> setRequestManager manager
+  EstimatorResponse {age} <- httpJSON req <&> getResponseBody
+  pure age
+
+-- Register the activity with Temporal's code generation
+Temporal.TH.registerActivity 'estimateAge
+
+-- | Workflow configuration options for activities
+activityOptions :: Workflow.StartActivityOptions
+activityOptions =
+  Workflow.defaultStartActivityOptions (Workflow.StartToClose $ seconds 30)
+
+estimateAgeWorkflow :: Text -> Workflow Text
+estimateAgeWorkflow name = provideCallStack $ do
+  age <- Workflow.executeActivity EstimateAge activityOptions name
+  pure $ name <> " has an estimated age of " <> tshow age
+
+Temporal.TH.registerWorkflow 'estimateAgeWorkflow

--- a/temporal102/samples/age-estimation/age-estimation.cabal
+++ b/temporal102/samples/age-estimation/age-estimation.cabal
@@ -1,0 +1,73 @@
+cabal-version: 3.0
+
+name:       age-estimation
+version:    0.0.0
+license:    MPL-2.0
+build-type: Simple
+author:     Mercury Technologies Inc.
+maintainer: temporal@mercury.com
+copyright:  2025 Mercury Technologies Inc.
+
+common all
+  default-language: GHC2021
+  default-extensions:
+    BlockArguments,
+    DeriveAnyClass,
+    DerivingVia,
+    LambdaCase,
+    OverloadedRecordDot,
+    OverloadedStrings,
+    RecordWildCards,
+    TemplateHaskell,
+    TypeFamilies,
+    UndecidableInstances,
+  ghc-options: -threaded -rtsopts -with-rtsopts=-N
+  build-depends:
+    base,
+    bytestring,
+    aeson,
+    containers,
+    crypton-connection,
+    data-default,
+    discover-instances,
+    http-conduit,
+    http-client,
+    http-client-tls,
+    http-types,
+    monad-logger,
+    mtl,
+    require-callstack,
+    text,
+    temporal-sdk-core,
+    temporal-sdk,
+    time,
+    tls,
+    transformers,
+    unliftio,
+    uuid,
+  hs-source-dirs: .
+
+common executables
+
+library
+  import: all
+  hs-source-dirs: ./
+  exposed-modules:
+    Shared,
+    Workflow
+
+executable client
+  import: all, executables
+  main-is: Client.hs
+  hs-source-dirs: ./
+  other-modules:
+    Shared,
+    Workflow
+
+executable worker
+  import: all, executables
+  main-is: Worker.hs
+  hs-source-dirs: ./
+  other-modules:
+    Shared,
+    Workflow

--- a/temporal102/samples/age-estimation/age-estimation.cabal
+++ b/temporal102/samples/age-estimation/age-estimation.cabal
@@ -71,3 +71,22 @@ executable worker
   other-modules:
     Shared,
     Workflow
+
+test-suite spec
+  import: all
+  type: exitcode-stdio-1.0
+  hs-source-dirs: tests
+  main-is: Spec.hs
+  other-modules:
+    -- System under test.
+    Shared,
+    Workflow,
+    -- Common testing functionality.
+    TestUtils,
+    -- Test implementation.
+    ActivitySpec,
+    WorkflowSpec,
+  build-depends:
+    directory,
+    hspec,
+    hspec-expectations

--- a/temporal102/samples/age-estimation/age-estimation.cabal
+++ b/temporal102/samples/age-estimation/age-estimation.cabal
@@ -85,7 +85,8 @@ test-suite spec
     TestUtils,
     -- Test implementation.
     ActivitySpec,
-    WorkflowSpec,
+    MockWorkflowSpec,
+    WorkflowSpec
   build-depends:
     directory,
     hspec,

--- a/temporal102/samples/age-estimation/tests/ActivitySpec.hs
+++ b/temporal102/samples/age-estimation/tests/ActivitySpec.hs
@@ -1,0 +1,1 @@
+module ActivitySpec where

--- a/temporal102/samples/age-estimation/tests/ActivitySpec.hs
+++ b/temporal102/samples/age-estimation/tests/ActivitySpec.hs
@@ -1,1 +1,22 @@
-module ActivitySpec where
+module ActivitySpec (spec) where
+
+import Workflow (estimateAge)
+
+import TestUtils
+
+import Network.HTTP.Client qualified as HTTP.Client
+import Test.Hspec
+import Test.Hspec.Expectations
+import Temporal.Testing.MockActivityEnvironment (MockActivityEnvironment, runMockActivity)
+
+-- | Prepare a mock environment and provide it to the activities under test.
+spec :: Spec
+spec = aroundAll withMockActivityEnvironment $
+  activitySpec
+
+-- | Test the age estimation activity in a mocked environment.
+activitySpec :: SpecWith (MockActivityEnvironment HTTP.Client.Manager)
+activitySpec = describe "age estimation activity" do
+  it "runs the 'estimateAge' activity in a mocked environment" \env -> do
+    age <- runMockActivity env $ estimateAge "Betty"
+    age `shouldBe` 78

--- a/temporal102/samples/age-estimation/tests/MockWorkflowSpec.hs
+++ b/temporal102/samples/age-estimation/tests/MockWorkflowSpec.hs
@@ -1,0 +1,85 @@
+module MockWorkflowSpec (spec) where
+
+import Workflow (
+    EstimateAge (..),
+    EstimateAgeWorkflow (..),
+    estimateAgeWorkflow
+  )
+import Shared
+import TestUtils
+
+import Control.Monad.Logger (defaultOutput)
+import Control.Monad.Reader (runReaderT)
+import Data.Text (Text)
+import DiscoverInstances (discoverInstances)
+import RequireCallStack (RequireCallStack, provideCallStack)
+import System.IO (stdout)
+import Temporal.Activity (
+    Activity,
+    ProvidedActivity,
+    provideActivity
+  )
+import Temporal.Client qualified as Client
+import Temporal.Client (WorkflowClient)
+import Temporal.Payload (JSON (JSON))
+import Temporal.TH (WorkflowFn, ActivityFn)
+import Temporal.TH qualified
+import Temporal.Worker (WorkerConfig)
+import Temporal.Worker qualified as Worker
+import Temporal.Workflow (
+    ProvidedWorkflow,
+    Workflow,
+    activityRef,
+    knownActivityName,
+    knownWorkflowName,
+    provideWorkflow,
+    workflowRef,
+  )
+import Test.Hspec
+import Test.Hspec.Expectations
+
+spec :: Spec
+spec =
+  aroundAll withDevServer
+    . aroundAllWith (withWorker workerConfig)
+    . aroundAllWith (withTestClient Shared.namespace)
+    $ mockWorkflowSpec
+
+mockWorkflowSpec :: SpecWith WorkflowClient
+mockWorkflowSpec = describe "mocked EstimateAge workflow" do
+  it "runs estimateAgeWorkflow with a mocked activity call" \client -> do
+    message <- flip runReaderT client do
+      Client.execute
+        EstimateAgeWorkflow
+        "test"
+        (Client.startWorkflowOptions Shared.taskQueue)
+        "Betty"
+    message `shouldBe` "Betty has an estimated age of 78"
+
+-- | Configure a worker that dispatches incoming 'EstimateAgeWorkflow' calls
+-- to the stubbed activity implementation defined below.
+workerConfig :: WorkerConfig ()
+workerConfig = provideCallStack $ Worker.configure () definitions settings
+  where
+    definitions = (activity, workflow)
+    settings = do
+      Worker.setNamespace Shared.namespace
+      Worker.setTaskQueue Shared.taskQueue
+      Worker.setLogger (defaultOutput stdout)
+
+-- | Manually construct the 'ProvidedWorkflow', since Template Haskell
+-- discovery would automatically pick up the real activity implementation and
+-- not the mock.
+workflow :: ProvidedWorkflow (Text -> Workflow Text)
+workflow = provideWorkflow JSON name estimateAgeWorkflow
+  where
+    name = knownWorkflowName (workflowRef EstimateAgeWorkflow)
+
+-- | Manually construct a 'ProvidedActivity' implementation that conforms to
+-- the same interface that 'EstimateAgeWorkflow' expects, but stubs out the
+-- actual 'Activity' call and elides the custom HTTP client manager we provide
+-- in the real implementation's execution environment.
+activity :: ProvidedActivity () (Text -> Activity () Int)
+activity = provideActivity JSON name (\_ -> pure 78)
+  where
+    name = knownActivityName (activityRef EstimateAge)

--- a/temporal102/samples/age-estimation/tests/Spec.hs
+++ b/temporal102/samples/age-estimation/tests/Spec.hs
@@ -1,6 +1,7 @@
 module Main where
 
 import ActivitySpec qualified
+import MockWorkflowSpec qualified
 import WorkflowSpec qualified
 
 import Test.Hspec
@@ -8,4 +9,5 @@ import Test.Hspec
 main :: IO ()
 main = hspec do
   ActivitySpec.spec
+  MockWorkflowSpec.spec
   WorkflowSpec.spec

--- a/temporal102/samples/age-estimation/tests/Spec.hs
+++ b/temporal102/samples/age-estimation/tests/Spec.hs
@@ -1,0 +1,9 @@
+module Main where
+
+import WorkflowSpec qualified
+
+import Test.Hspec
+
+main :: IO ()
+main = hspec do
+  WorkflowSpec.spec

--- a/temporal102/samples/age-estimation/tests/Spec.hs
+++ b/temporal102/samples/age-estimation/tests/Spec.hs
@@ -1,9 +1,11 @@
 module Main where
 
+import ActivitySpec qualified
 import WorkflowSpec qualified
 
 import Test.Hspec
 
 main :: IO ()
 main = hspec do
+  ActivitySpec.spec
   WorkflowSpec.spec

--- a/temporal102/samples/age-estimation/tests/TestUtils.hs
+++ b/temporal102/samples/age-estimation/tests/TestUtils.hs
@@ -1,0 +1,76 @@
+module TestUtils where
+
+import Shared qualified
+
+import qualified Data.Text as Text
+import Control.Monad.Logger (runStdoutLoggingT)
+import Network.HTTP.Client qualified as HTTP.Client
+import System.Directory (findExecutable)
+import System.IO.Unsafe (unsafePerformIO)
+import Test.Hspec
+import qualified Temporal.Client as Client
+import Temporal.Client (WorkflowClient, WorkflowClientConfig, mkWorkflowClientConfig, workflowClient)
+import Temporal.Core.Client (ClientConfig (..), connectClient, defaultClientConfig)
+import qualified Temporal.Core.Client as Core
+import Temporal.EphemeralServer (
+    EphemeralExe(..),
+    PortNumber,
+    TemporalDevServerConfig(..),
+    defaultTemporalDevServerConfig,
+    getFreePort,
+  )
+import Temporal.EphemeralServer qualified as EphemeralServer
+import Temporal.Runtime (TelemetryOptions(NoTelemetry), Runtime, initializeRuntime)
+import Temporal.Worker (WorkerConfig)
+import qualified Temporal.Worker as Worker
+import qualified Temporal.Workflow as Workflow
+import UnliftIO.Exception (bracket, throwIO)
+
+-- | Construct an ephemeral test server running on a free port and make it,
+-- along with connected 'Core.Client', available within the scope of some
+-- function under test.
+--
+-- Typically precedes a call to 'withTimeSkippingClient'.
+withDevServer :: (Core.Client -> IO a) -> IO a
+withDevServer action = do
+  port <- getFreePort
+  config <- findExecutable "temporal" >>= \case
+    Nothing -> throwIO $ userError "unable to find 'temporal'"
+    Just exe -> pure defaultTemporalDevServerConfig {
+        exe = ExistingPath exe,
+        port = Just $ fromIntegral port
+      }
+  EphemeralServer.withDevServer globalRuntime config \_server -> do
+    let coreConfig = defaultClientConfig { targetUrl = "http://localhost:" <> (Text.pack . show $ port) }
+    coreClient <- runStdoutLoggingT $ connectClient globalRuntime coreConfig
+    action coreClient
+
+-- | Construct a 'Worker' connected to a server associated with the given
+-- 'Core.Client' and make it available to the function under test.
+--
+-- Typically follows a call to set up an ephemeral server, such as
+-- 'withDevServer'.
+withWorker :: WorkerConfig env -> ActionWith Core.Client -> ActionWith Core.Client
+withWorker config action coreClient = do
+  bracket (Worker.startWorker coreClient config) Worker.shutdown \_ -> do
+    action coreClient
+
+-- | Construct a 'WorkflowClient' connected to a server associated with the
+-- given 'Core.Client' and make it available to the function under test.
+--
+-- Typically follows a call to 'withDevServer'.
+withTestClient :: Workflow.Namespace -> ActionWith WorkflowClient -> ActionWith Core.Client
+withTestClient namespace action coreClient = do
+  client <- workflowClient coreClient $ (mkWorkflowClientConfig namespace)
+  action client
+
+-- | A global Tokio 'Runtime' scoped to the test process.
+globalRuntime :: Runtime
+globalRuntime = unsafePerformIO $ initializeRuntime NoTelemetry
+{-# NOINLINE globalRuntime #-}
+
+-- | A global HTTP connection manager with TLS settings that permit responses
+-- without an Extended Main Secret.
+globalRelaxedEMSManager :: HTTP.Client.Manager
+globalRelaxedEMSManager = unsafePerformIO Shared.newRelaxedEMSManager
+{-# NOINLINE globalRelaxedEMSManager #-}

--- a/temporal102/samples/age-estimation/tests/WorkflowSpec.hs
+++ b/temporal102/samples/age-estimation/tests/WorkflowSpec.hs
@@ -1,0 +1,34 @@
+module WorkflowSpec where
+
+import Shared qualified
+import Workflow (EstimateAgeWorkflow (..))
+
+import TestUtils
+
+import Control.Monad.Trans.Reader (runReaderT)
+import Test.Hspec
+import Test.Hspec.Expectations
+import Temporal.Client (WorkflowClient)
+import qualified Temporal.Client as Client
+import Temporal.Worker (WorkerConfig)
+
+-- | Prepare the local dev server & worker process on a free port, then pass
+-- a 'WorkflowClient' that can communicate with them to the test suite.
+spec :: Spec
+spec =
+  aroundAll withDevServer
+    . aroundAllWith (withWorker $ Shared.mkWorkerConfig globalRelaxedEMSManager)
+    . aroundAllWith (withTestClient Shared.namespace)
+    $ workflowSpec
+
+-- | Test the age estimation workflow using the local dev server.
+workflowSpec :: SpecWith WorkflowClient
+workflowSpec = describe "EstimateAge workflow" do
+  it "runs estimateAgeWorkflow with activity call" \client -> do
+    message <- flip runReaderT client do
+      Client.execute
+        EstimateAgeWorkflow
+        "test"
+        (Client.startWorkflowOptions Shared.taskQueue)
+        "Betty"
+    message `shouldBe` "Betty has an estimated age of 78"


### PR DESCRIPTION
## description

so it turns out that the API used as part of this sample doesn't support TLS1.2+EMS (Extended Main Secret), which 'http-client-tls' is set up to require by default.

there are a few ways we could have handled this, but I think it actually makes for a nice example for how dependency injection works for the activity's 'MonadReader' instance.