### PR TITLE
fix(age-estimation): test framework mock provider

### DIFF
--- a/temporal102/samples/age-estimation/tests/ActivitySpec.hs
+++ b/temporal102/samples/age-estimation/tests/ActivitySpec.hs
@@ -11,7 +11,7 @@ import Temporal.Testing.MockActivityEnvironment (MockActivityEnvironment, runMoc
 
 -- | Prepare a mock environment and provide it to the activities under test.
 spec :: Spec
-spec = aroundAll withMockActivityEnvironment $
+spec = around withMockActivityEnvironment $
   activitySpec
 
 -- | Test the age estimation activity in a mocked environment.

--- a/temporal102/samples/age-estimation/tests/TestUtils.hs
+++ b/temporal102/samples/age-estimation/tests/TestUtils.hs
@@ -31,7 +31,7 @@ import UnliftIO.Exception (bracket, throwIO)
 -- along with connected 'Core.Client', available within the scope of some
 -- function under test.
 --
--- Typically precedes a call to 'withTimeSkippingClient'.
+-- Typically precedes a call to 'withTestClient'.
 withDevServer :: (Core.Client -> IO a) -> IO a
 withDevServer action = do
   port <- getFreePort


### PR DESCRIPTION
## description

just what it says on the tin: producing the `MockActivityEnvironment` should be an `around`, not an `aroundAll`, because we want to provide a fresh environment for each spec item.

it's kind of a moot point for this example, since there's only one spec item, but I want people to have a good example in case they incorporate this pattern into their own test cases.

without a fresh `MockActivityEnvironment` for each spec, the stateful component tracking heartbeat payloads will leak in between specs.